### PR TITLE
feat(powersupplyunit): add a RawData() function

### DIFF
--- a/redfish/powersupplyunit.go
+++ b/redfish/powersupplyunit.go
@@ -288,3 +288,7 @@ func (powerSupplyUnit *PowerSupplyUnit) PowerOutlets() ([]*Outlet, error) {
 func (powerSupplyUnit *PowerSupplyUnit) PoweringChassis() ([]*Chassis, error) {
 	return common.GetObjects[Chassis](powerSupplyUnit.GetClient(), powerSupplyUnit.poweringChassis)
 }
+
+func (powerSupplyUnit *PowerSupplyUnit) RawData() []byte {
+	return powerSupplyUnit.rawData
+}


### PR DESCRIPTION
`PowerSupplyUnit` does not read in `Oem` information. E.g.

```
  "Model": "ECD17020039",
  "Name": "PowerSupplyUnit 1",
  "Oem": {
    "deltaenergysystems": {
      "@odata.id": "/redfish/v1/Chassis/PowerShelf_0/PowerSubsystem/PowerSupplies/1#/Oem/deltaenergysystems",
      "@odata.type": "#DeltaEnergySystemsPowerSupply.v1_0_0.PowerSupply",
      "FanSpeedTarget": 0,
      "Power": false
    }
```

Add a RawData() endpoint to get the raw []byte, and handle json unmarshaling from the app code, 