### PR TITLE
feat: Trusted Component TPM should use updated struct rather than string

### DIFF
--- a/redfish/trustedcomponent.go
+++ b/redfish/trustedcomponent.go
@@ -106,7 +106,7 @@ type TrustedComponent struct {
 	Status common.Status
 	// TPM shall contain TPM-specific information for this trusted component. This property shall only be present for
 	// TCG-defined TPM trusted components.
-	TPM string
+	TPM TPM `json:"TPM,omitempty"`
 	// TrustedComponentType shall contain the type of trusted component.
 	TrustedComponentType TrustedComponentType
 	// UUID shall contain a universally unique identifier number for the trusted component.


### PR DESCRIPTION
Since the TrustedComponent schema became available in Redfish Release 2022.2, it has been an object rather than a string. Gofish currently features a TPM string field, but there is a TPM struct present, which matches the actual redfish schema.

This PR proposes a change to utilize the TPM struct, and will allow users to successfully Unmarshal TrustedComponents from redfish.

```
...
  "TPM": {
    "CapabilitiesVendorID": "IFX",
    "HardwareInterfaceVendorID": "0x15D1"
  },
...
```