### PR TITLE
Pull latest changes from upstream

### DIFF
--- a/redfish/trustedcomponent.go
+++ b/redfish/trustedcomponent.go
@@ -106,7 +106,7 @@ type TrustedComponent struct {
 	Status common.Status
 	// TPM shall contain TPM-specific information for this trusted component. This property shall only be present for
 	// TCG-defined TPM trusted components.
-	TPM string
+	TPM TPM
 	// TrustedComponentType shall contain the type of trusted component.
 	TrustedComponentType TrustedComponentType
 	// UUID shall contain a universally unique identifier number for the trusted component.


### PR DESCRIPTION
This will include updates to the redfish http client to support a tls configuration.

And it will also fix the TrustedComponent TPM field - changing it from a string to an object.