### PR TITLE
temp fix: use 'any' type for RackOffset field

### DIFF
--- a/common/types.go
+++ b/common/types.go
@@ -369,7 +369,7 @@ type Placement struct {
 	Rack string
 	// RackOffset is the vertical location of the item in the rack. Rack offset
 	// units shall be measured from bottom to top starting with 0.
-	RackOffset int
+	RackOffset any
 	// RackOffsetUnits shall be a RackUnit enumeration literal indicating the
 	// type of rack units in use.
 	RackOffsetUnits RackUnits


### PR DESCRIPTION
Delta Powershelf on PMC firmware 3.1.7 has a `string` type for Chassis field `location.placement.rackoffset`.

```
curl -sk https://10.188.13.2/redfish/v1/Chassis/PowerShelf_0 -u coreweave:’REDACT’ | jq .Location
{
  "Placement": {
    "AdditionalInfo": "",
    "Rack": "",
    "RackOffset": "",
    "RackOffsetUnits": null,
    "Row": ""
  }
}
```

In upstream gofish, and the DMTF (2025-02-05 Version: 1.1.0 page 26) spec - this is an `int` type. This should be an EVR request, but until FW fixes this and is rolled out to delta powershelves, we can use this as a stopgap so metaldev tooling doesn't break.

This field isn't used directly in any metaldev code - this change simply allows us to unmarshal redfish chassis into the gofish type.