### PR TITLE
export rawdata field for powersupplyunits

### DIFF
--- a/redfish/powersupplyunit.go
+++ b/redfish/powersupplyunit.go
@@ -153,7 +153,7 @@ type PowerSupplyUnit struct {
 	OemActions json.RawMessage
 
 	// rawData holds the original serialized JSON so we can compare updates.
-	rawData []byte
+	RawData []byte
 }
 
 // UnmarshalJSON unmarshals a PowerSupplyUnit object from the raw JSON.


### PR DESCRIPTION
Requesting that rawData is an exported field for power supply units. This is because we have seen instances vendors use the deprecated PowerSupplies endpoint instead of the link in the chassis resource.

```
// Deprecated: (v1.3) in favor of the PowerSupplies link in the Chassis resource.
func (powerDistribution *PowerDistribution) PowerSupplies() ([]*PowerSupplyUnit, error) {
	return ListReferencedPowerSupplyUnits(powerDistribution.GetClient(), powerDistribution.powerSupplies)
}
```

However the resource that is returned  is actually a `PowerSupply` resource. Having access to the RawData you to directly unmarshal into the correct type.

This also appears to be an established pattern with other examples in the repo of being able to access RawData as an exported field.