### PR TITLE
add (hardware) version field to PowerSupply resource

### DIFF
--- a/redfish/power.go
+++ b/redfish/power.go
@@ -388,6 +388,8 @@ type PowerSupply struct {
 	SparePartNumber string `json:"SparePartNumber,omitempty"`
 	// Status contains status and health properties of this resource.
 	Status common.Status `json:"Status,omitempty"`
+	// The hardware version of this power supply.
+	Version string
 
 	rawData          []byte
 	assembly         string


### PR DESCRIPTION
I think Delta is flashing the wrong values in FRU, I need to add `Version` (= hardware revision) to create a metric to find all of the cases where they are doing that.